### PR TITLE
Pub export MemoryBlock

### DIFF
--- a/gpu-alloc/src/lib.rs
+++ b/gpu-alloc/src/lib.rs
@@ -36,7 +36,7 @@ mod slab;
 mod usage;
 
 pub use {
-    self::{allocator::*, config::*, error::*, usage::*},
+    self::{allocator::*, block::MemoryBlock, config::*, error::*, usage::*},
     gpu_alloc_types::*,
 };
 


### PR DESCRIPTION
Currently, `allocate` returns something that's not exposed in public.