### PR TITLE
Fix dedicated budget check

### DIFF
--- a/gpu-alloc/src/allocator.rs
+++ b/gpu-alloc/src/allocator.rs
@@ -257,7 +257,7 @@ where
 
             match strategy {
                 Strategy::Dedicated => {
-                    if !heap.budget() >= request.size {
+                    if heap.budget() < request.size {
                         continue;
                     }
 


### PR DESCRIPTION
This is the first time I see that Rust's mix of '!' for boolean and numbers is confusing. I always considered it clear, previously.