### PR TITLE
Update erupt to 0.16.0+162

### DIFF
--- a/erupt/Cargo.toml
+++ b/erupt/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/zakarumych/gpu-alloc"
 [dependencies]
 gpu-alloc-types = { path = "../types", version = "0.1" }
 tracing = { version = "0.1", features = ["attributes"], optional = true }
-erupt = { version = "0.15", default-features = false, features = ["loading"] }
+erupt = { version = "0.16", default-features = false, features = ["loading"] }
 tinyvec = { version = "1.0",  default-features = false, features = ["alloc"] }

--- a/erupt/src/lib.rs
+++ b/erupt/src/lib.rs
@@ -252,8 +252,8 @@ pub unsafe fn device_properties(
     let memory_properties = instance.get_physical_device_memory_properties(physical_device, None);
 
     let buffer_device_address =
-        if instance.enabled.vk1_1 || instance.enabled.khr_get_display_properties2 {
-            let mut bda_features_available = instance.enabled.vk1_2;
+        if instance.enabled().vk1_1 || instance.enabled().khr_get_display_properties2 {
+            let mut bda_features_available = instance.enabled().vk1_2;
 
             if !bda_features_available {
                 let extensions = instance

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ gpu-alloc-gfx = { path = "../gfx", version = "=0.1", optional = true }
 gfx-hal = { version = "0.6", optional = true }
 gfx-backend-vulkan = { version = "0.6", optional = true }
 gpu-alloc-erupt = { path = "../erupt", version = "=0.1", optional = true }
-erupt = { version = "0.15", optional = true, features = ["loading"] }
+erupt = { version = "0.16", optional = true, features = ["loading"] }
 
 [[bin]]
 name = "mock"


### PR DESCRIPTION
[erupt changelog](https://gitlab.com/Friz64/erupt/-/blob/master/CHANGELOG.md#0160162-2020-11-24)

Thank you very much for your work on `gpu-alloc`!
