### PR TITLE
Fix Coherent Memory Flushes in write_bytes

### DIFF
--- a/gpu-alloc/src/block.rs
+++ b/gpu-alloc/src/block.rs
@@ -252,7 +252,7 @@ impl<M> MemoryBlock<M> {
 
             device.flush_memory_ranges(&[MappedMemoryRange {
                 memory: &self.memory,
-                offset: aligned_offset,
+                offset: self.offset + aligned_offset,
                 size,
             }])
         } else {
@@ -296,7 +296,7 @@ impl<M> MemoryBlock<M> {
 
             device.invalidate_memory_ranges(&[MappedMemoryRange {
                 memory: &self.memory,
-                offset: aligned_offset,
+                offset: self.offset + aligned_offset,
                 size,
             }])
         } else {


### PR DESCRIPTION
Currently, write_bytes does not take into account a memory sub-allocation's offset when flushing coherent memory in write_bytes. For example if the suballocation was 200..300, it would ask 0..100 to be flushed.

I'm not sure this is an entirely correct fix but did fix wgpu's DX11 examples.