### PR TITLE
Change MemoryDevice::map/unmap_memory

### DIFF
--- a/erupt/src/lib.rs
+++ b/erupt/src/lib.rs
@@ -143,7 +143,7 @@ impl MemoryDevice<vk1_0::DeviceMemory> for EruptMemoryDevice {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn map_memory(
         &self,
-        memory: &vk1_0::DeviceMemory,
+        memory: &mut vk1_0::DeviceMemory,
         offset: u64,
         size: u64,
     ) -> Result<NonNull<u8>, DeviceMapError> {
@@ -168,7 +168,7 @@ impl MemoryDevice<vk1_0::DeviceMemory> for EruptMemoryDevice {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
-    unsafe fn unmap_memory(&self, memory: &vk1_0::DeviceMemory) {
+    unsafe fn unmap_memory(&self, memory: &mut vk1_0::DeviceMemory) {
         self.device.unmap_memory(*memory);
     }
 

--- a/examples/src/erupt.rs
+++ b/examples/src/erupt.rs
@@ -46,7 +46,7 @@ fn main() -> eyre::Result<()> {
 
     let mut allocator = GpuAllocator::new(config, props);
 
-    let block = unsafe {
+    let mut block = unsafe {
         allocator.alloc(
             EruptMemoryDevice::wrap(&device),
             Request {

--- a/examples/src/gfx.rs
+++ b/examples/src/gfx.rs
@@ -58,7 +58,7 @@ fn main() -> eyre::Result<()> {
 
     let mut allocator = GpuAllocator::new(config, props);
 
-    let block = unsafe {
+    let mut block = unsafe {
         allocator.alloc(
             GfxMemoryDevice::wrap(&device),
             Request {

--- a/examples/src/mock.rs
+++ b/examples/src/mock.rs
@@ -26,7 +26,7 @@ fn main() -> eyre::Result<()> {
 
     let mut allocator = GpuAllocator::new(config, device.props());
 
-    let block = unsafe {
+    let mut block = unsafe {
         allocator.alloc(
             &device,
             Request {

--- a/gpu-alloc/src/allocator.rs
+++ b/gpu-alloc/src/allocator.rs
@@ -130,10 +130,7 @@ where
         &mut self,
         device: &impl MemoryDevice<M>,
         request: Request,
-    ) -> Result<MemoryBlock<M>, AllocationError>
-    where
-        M: Clone,
-    {
+    ) -> Result<MemoryBlock<M>, AllocationError> {
         self.alloc_internal(device, request, None)
     }
 
@@ -153,10 +150,7 @@ where
         device: &impl MemoryDevice<M>,
         request: Request,
         dedicated: Dedicated,
-    ) -> Result<MemoryBlock<M>, AllocationError>
-    where
-        M: Clone,
-    {
+    ) -> Result<MemoryBlock<M>, AllocationError> {
         self.alloc_internal(device, request, Some(dedicated))
     }
 
@@ -165,10 +159,7 @@ where
         device: &impl MemoryDevice<M>,
         mut request: Request,
         dedicated: Option<Dedicated>,
-    ) -> Result<MemoryBlock<M>, AllocationError>
-    where
-        M: Clone,
-    {
+    ) -> Result<MemoryBlock<M>, AllocationError> {
         enum Strategy {
             Linear,
             Buddy,
@@ -271,13 +262,12 @@ where
                             heap.alloc(request.size);
 
                             return Ok(MemoryBlock::new(
-                                memory,
                                 index,
                                 memory_type.props,
                                 0,
                                 request.size,
                                 atom_mask,
-                                MemoryBlockFlavor::Dedicated,
+                                MemoryBlockFlavor::Dedicated { memory },
                             ));
                         }
                         Err(OutOfMemory::OutOfDeviceMemory) => continue,
@@ -315,7 +305,6 @@ where
                     match result {
                         Ok(block) => {
                             return Ok(MemoryBlock::new(
-                                block.memory,
                                 index,
                                 memory_type.props,
                                 block.offset,
@@ -324,6 +313,7 @@ where
                                 MemoryBlockFlavor::Linear {
                                     chunk: block.chunk,
                                     ptr: block.ptr,
+                                    memory: block.memory,
                                 },
                             ))
                         }
@@ -371,7 +361,6 @@ where
                     match result {
                         Ok(block) => {
                             return Ok(MemoryBlock::new(
-                                block.memory,
                                 index,
                                 memory_type.props,
                                 block.offset,
@@ -381,6 +370,7 @@ where
                                     chunk: block.chunk,
                                     ptr: block.ptr,
                                     index: block.index,
+                                    memory: block.memory,
                                 },
                             ))
                         }
@@ -407,15 +397,15 @@ where
         let memory_type = block.memory_type();
         let offset = block.offset();
         let size = block.size();
-        let (memory, flavor) = block.deallocate();
+        let flavor = block.deallocate();
         match flavor {
-            MemoryBlockFlavor::Dedicated => {
+            MemoryBlockFlavor::Dedicated { memory } => {
                 let heap = self.memory_types[memory_type as usize].heap;
                 device.deallocate_memory(memory);
                 self.allocations_remains += 1;
                 self.memory_heaps[heap as usize].dealloc(size);
             }
-            MemoryBlockFlavor::Linear { chunk, ptr } => {
+            MemoryBlockFlavor::Linear { chunk, ptr, memory } => {
                 let heap = self.memory_types[memory_type as usize].heap;
                 let heap = &mut self.memory_heaps[heap as usize];
 
@@ -436,7 +426,12 @@ where
                     &mut self.allocations_remains,
                 );
             }
-            MemoryBlockFlavor::Buddy { chunk, ptr, index } => {
+            MemoryBlockFlavor::Buddy {
+                chunk,
+                ptr,
+                index,
+                memory,
+            } => {
                 let memory_type = memory_type;
                 let heap = self.memory_types[memory_type as usize].heap;
                 let heap = &mut self.memory_heaps[heap as usize];

--- a/gpu-alloc/src/block.rs
+++ b/gpu-alloc/src/block.rs
@@ -1,9 +1,10 @@
 use {
     crate::{align_down, align_up, error::MapError},
+    alloc::sync::Arc,
     core::{
         convert::TryFrom as _,
         ptr::{copy_nonoverlapping, NonNull},
-        sync::atomic::{AtomicU8, Ordering::*},
+        // sync::atomic::{AtomicU8, Ordering::*},
     },
     gpu_alloc_types::{MappedMemoryRange, MemoryDevice, MemoryPropertyFlags},
 };
@@ -28,52 +29,44 @@ impl Drop for Relevant {
     }
 }
 
-const MAPPING_STATE_UNMAPPED: u8 = 0;
-const MAPPING_STATE_MAPPING: u8 = 1;
-const MAPPING_STATE_MAPPED: u8 = 2;
-const MAPPING_STATE_UNMAPPING: u8 = 3;
-
 /// Memory block allocated by `GpuAllocator`.
 #[derive(Debug)]
 pub struct MemoryBlock<M> {
-    memory: M,
     memory_type: u32,
     props: MemoryPropertyFlags,
     offset: u64,
     size: u64,
     atom_mask: u64,
-    mapped: AtomicU8,
-    flavor: MemoryBlockFlavor,
+    mapped: bool,
+    flavor: MemoryBlockFlavor<M>,
     relevant: Relevant,
 }
 
 impl<M> MemoryBlock<M> {
     pub(crate) fn new(
-        memory: M,
         memory_type: u32,
         props: MemoryPropertyFlags,
         offset: u64,
         size: u64,
         atom_mask: u64,
-        flavor: MemoryBlockFlavor,
+        flavor: MemoryBlockFlavor<M>,
     ) -> Self {
         isize::try_from(atom_mask).expect("`atom_mask` is too large");
         MemoryBlock {
-            memory,
             memory_type,
             props,
             offset,
             size,
             atom_mask,
             flavor,
-            mapped: AtomicU8::new(MAPPING_STATE_UNMAPPED),
+            mapped: false,
             relevant: Relevant,
         }
     }
 
-    pub(crate) fn deallocate(self) -> (M, MemoryBlockFlavor) {
+    pub(crate) fn deallocate(self) -> MemoryBlockFlavor<M> {
         core::mem::forget(self.relevant);
-        (self.memory, self.flavor)
+        self.flavor
     }
 }
 
@@ -81,16 +74,20 @@ unsafe impl<M> Sync for MemoryBlock<M> where M: Sync {}
 unsafe impl<M> Send for MemoryBlock<M> where M: Send {}
 
 #[derive(Debug)]
-pub(crate) enum MemoryBlockFlavor {
-    Dedicated,
+pub(crate) enum MemoryBlockFlavor<M> {
+    Dedicated {
+        memory: M,
+    },
     Linear {
         chunk: u64,
         ptr: Option<NonNull<u8>>,
+        memory: Arc<M>,
     },
     Buddy {
         chunk: usize,
         index: usize,
         ptr: Option<NonNull<u8>>,
+        memory: Arc<M>,
     },
 }
 
@@ -98,7 +95,11 @@ impl<M> MemoryBlock<M> {
     /// Returns reference to parent memory object.
     #[inline(always)]
     pub fn memory(&self) -> &M {
-        &self.memory
+        match &self.flavor {
+            MemoryBlockFlavor::Dedicated { memory } => memory,
+            MemoryBlockFlavor::Buddy { memory, .. } => &**memory,
+            MemoryBlockFlavor::Linear { memory, .. } => &**memory,
+        }
     }
 
     /// Returns offset in bytes from start of memory object to start of this block.
@@ -146,7 +147,7 @@ impl<M> MemoryBlock<M> {
     /// `block` must have been allocated from specified `device`.
     #[inline(always)]
     pub unsafe fn map(
-        &self,
+        &mut self,
         device: &impl MemoryDevice<M>,
         offset: u64,
         size: usize,
@@ -158,37 +159,33 @@ impl<M> MemoryBlock<M> {
             "`offset + size` is out of memory block bounds"
         );
 
-        let ptr = match self.flavor {
-            MemoryBlockFlavor::Dedicated => {
+        let ptr = match &mut self.flavor {
+            MemoryBlockFlavor::Dedicated { memory } => {
                 let end = align_up(offset + size_u64, self.atom_mask)
                     .expect("mapping end doesn't fit device address space");
                 let aligned_offset = align_down(offset, self.atom_mask);
 
-                if !self.start_mapping() {
+                if !acquire_mapping(&mut self.mapped) {
                     return Err(MapError::AlreadyMapped);
                 }
-                let result = device.map_memory(
-                    &self.memory,
-                    self.offset + aligned_offset,
-                    end - aligned_offset,
-                );
+                let result =
+                    device.map_memory(memory, self.offset + aligned_offset, end - aligned_offset);
 
                 match result {
                     // the overflow is checked in `Self::new()`
                     Ok(ptr) => {
-                        self.end_mapping();
                         let ptr_offset = (offset - aligned_offset) as isize;
                         ptr.as_ptr().offset(ptr_offset)
                     }
                     Err(err) => {
-                        self.mapping_failed();
+                        release_mapping(&mut self.mapped);
                         return Err(err.into());
                     }
                 }
             }
             MemoryBlockFlavor::Linear { ptr: Some(ptr), .. }
             | MemoryBlockFlavor::Buddy { ptr: Some(ptr), .. } => {
-                if !self.acquire_mapping() {
+                if !acquire_mapping(&mut self.mapped) {
                     return Err(MapError::AlreadyMapped);
                 }
                 let offset_isize = isize::try_from(offset)
@@ -212,18 +209,17 @@ impl<M> MemoryBlock<M> {
     ///
     /// `block` must have been allocated from specified `device`.
     #[inline(always)]
-    pub unsafe fn unmap(&self, device: &impl MemoryDevice<M>) -> bool {
-        if !self.start_unmapping() {
+    pub unsafe fn unmap(&mut self, device: &impl MemoryDevice<M>) -> bool {
+        if !release_mapping(&mut self.mapped) {
             return false;
         }
-        match self.flavor {
-            MemoryBlockFlavor::Dedicated => {
-                device.unmap_memory(&self.memory);
+        match &mut self.flavor {
+            MemoryBlockFlavor::Dedicated { memory } => {
+                device.unmap_memory(memory);
             }
             MemoryBlockFlavor::Linear { .. } => {}
             MemoryBlockFlavor::Buddy { .. } => {}
         }
-        self.end_unmapping();
         true
     }
 
@@ -240,7 +236,7 @@ impl<M> MemoryBlock<M> {
     /// The caller must guarantee that any previously submitted command that reads or writes to this range has completed.
     #[inline(always)]
     pub unsafe fn write_bytes(
-        &self,
+        &mut self,
         device: &impl MemoryDevice<M>,
         offset: u64,
         data: &[u8],
@@ -254,7 +250,7 @@ impl<M> MemoryBlock<M> {
             let end = align_up(offset + data.len() as u64, self.atom_mask).unwrap();
 
             device.flush_memory_ranges(&[MappedMemoryRange {
-                memory: &self.memory,
+                memory: self.memory(),
                 offset: self.offset + aligned_offset,
                 size: end - aligned_offset,
             }])
@@ -279,7 +275,7 @@ impl<M> MemoryBlock<M> {
     /// The caller must guarantee that any previously submitted command that reads to this range has completed.
     #[inline(always)]
     pub unsafe fn read_bytes(
-        &self,
+        &mut self,
         device: &impl MemoryDevice<M>,
         offset: u64,
         data: &mut [u8],
@@ -298,7 +294,7 @@ impl<M> MemoryBlock<M> {
             let end = align_up(offset + data.len() as u64, self.atom_mask).unwrap();
 
             device.invalidate_memory_ranges(&[MappedMemoryRange {
-                memory: &self.memory,
+                memory: self.memory(),
                 offset: self.offset + aligned_offset,
                 size: end - aligned_offset,
             }])
@@ -313,54 +309,6 @@ impl<M> MemoryBlock<M> {
         result.map_err(Into::into)
     }
 
-    fn acquire_mapping(&self) -> bool {
-        self.mapped
-            .compare_exchange(
-                MAPPING_STATE_UNMAPPED,
-                MAPPING_STATE_MAPPED,
-                Acquire,
-                Relaxed,
-            )
-            .is_ok()
-    }
-
-    fn start_mapping(&self) -> bool {
-        self.mapped
-            .compare_exchange(
-                MAPPING_STATE_UNMAPPED,
-                MAPPING_STATE_MAPPING,
-                Acquire,
-                Relaxed,
-            )
-            .is_ok()
-    }
-
-    fn end_mapping(&self) {
-        debug_assert_eq!(self.mapped.load(Relaxed), MAPPING_STATE_MAPPING);
-        self.mapped.store(MAPPING_STATE_MAPPED, Release);
-    }
-
-    fn mapping_failed(&self) {
-        debug_assert_eq!(self.mapped.load(Relaxed), MAPPING_STATE_MAPPING);
-        self.mapped.store(MAPPING_STATE_UNMAPPED, Release);
-    }
-
-    fn start_unmapping(&self) -> bool {
-        self.mapped
-            .compare_exchange(
-                MAPPING_STATE_MAPPED,
-                MAPPING_STATE_UNMAPPING,
-                Acquire,
-                Relaxed,
-            )
-            .is_ok()
-    }
-
-    fn end_unmapping(&self) {
-        debug_assert_eq!(self.mapped.load(Relaxed), MAPPING_STATE_UNMAPPING);
-        self.mapped.store(MAPPING_STATE_UNMAPPED, Release);
-    }
-
     fn coherent(&self) -> bool {
         self.props.contains(MemoryPropertyFlags::HOST_COHERENT)
     }
@@ -368,5 +316,23 @@ impl<M> MemoryBlock<M> {
     #[cfg(feature = "tracing")]
     fn cached(&self) -> bool {
         self.props.contains(MemoryPropertyFlags::HOST_CACHED)
+    }
+}
+
+fn acquire_mapping(mapped: &mut bool) -> bool {
+    if *mapped {
+        false
+    } else {
+        *mapped = true;
+        true
+    }
+}
+
+fn release_mapping(mapped: &mut bool) -> bool {
+    if *mapped {
+        *mapped = false;
+        true
+    } else {
+        false
     }
 }

--- a/gpu-alloc/src/buddy.rs
+++ b/gpu-alloc/src/buddy.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         align_up, error::AllocationError, heap::Heap, slab::Slab, unreachable_unchecked,
-        MemoryBounds,
+        util::try_arc_unwrap, MemoryBounds,
     },
     alloc::{sync::Arc, vec::Vec},
     core::{convert::TryFrom as _, mem::replace, ptr::NonNull},
@@ -450,7 +450,7 @@ where
                     let chunk = self.chunks.remove(chunk);
                     drop(block);
 
-                    let memory = Arc::try_unwrap(chunk.memory)
+                    let memory = try_arc_unwrap(chunk.memory)
                         .expect("Memory shared after last block deallocated");
 
                     device.deallocate_memory(memory);

--- a/gpu-alloc/src/buddy.rs
+++ b/gpu-alloc/src/buddy.rs
@@ -3,14 +3,14 @@ use {
         align_up, error::AllocationError, heap::Heap, slab::Slab, unreachable_unchecked,
         MemoryBounds,
     },
-    alloc::vec::Vec,
+    alloc::{sync::Arc, vec::Vec},
     core::{convert::TryFrom as _, mem::replace, ptr::NonNull},
     gpu_alloc_types::{AllocationFlags, DeviceMapError, MemoryDevice, MemoryPropertyFlags},
 };
 
 #[derive(Debug)]
 pub(crate) struct BuddyBlock<M> {
-    pub memory: M,
+    pub memory: Arc<M>,
     pub ptr: Option<NonNull<u8>>,
     pub size: u64,
     pub chunk: usize,
@@ -262,7 +262,7 @@ impl Size {
 
 #[derive(Debug)]
 struct Chunk<M> {
-    memory: M,
+    memory: Arc<M>,
     ptr: Option<NonNull<u8>>,
     size: u64,
 }
@@ -323,10 +323,7 @@ where
         flags: AllocationFlags,
         heap: &mut Heap,
         allocations_remains: &mut u32,
-    ) -> Result<BuddyBlock<M>, AllocationError>
-    where
-        M: Clone,
-    {
+    ) -> Result<BuddyBlock<M>, AllocationError> {
         let align_mask = align_mask | self.atom_mask;
 
         let size = align_up(size, align_mask)
@@ -362,12 +359,12 @@ where
                 }
 
                 let chunk_size = self.minimal_size << (candidate_size_index + 1);
-                let memory = device.allocate_memory(chunk_size, self.memory_type, flags)?;
+                let mut memory = device.allocate_memory(chunk_size, self.memory_type, flags)?;
                 *allocations_remains -= 1;
                 heap.alloc(chunk_size);
 
                 let ptr = if host_visible {
-                    match device.map_memory(&memory, 0, chunk_size) {
+                    match device.map_memory(&mut memory, 0, chunk_size) {
                         Ok(ptr) => Some(ptr),
                         Err(DeviceMapError::OutOfDeviceMemory) => {
                             return Err(AllocationError::OutOfDeviceMemory)
@@ -381,7 +378,7 @@ where
                 };
 
                 let chunk = self.chunks.insert(Chunk {
-                    memory,
+                    memory: Arc::new(memory),
                     ptr,
                     size: chunk_size,
                 });
@@ -446,11 +443,17 @@ where
                 }
                 Release::Chunk(chunk) => {
                     debug_assert_eq!(chunk, block.chunk);
+                    debug_assert_eq!(
+                        self.chunks.get(chunk).size,
+                        self.minimal_size << (release_size_index + 1)
+                    );
                     let chunk = self.chunks.remove(chunk);
-                    debug_assert_eq!(chunk.size, self.minimal_size << (release_size_index + 1));
-
                     drop(block);
-                    device.deallocate_memory(chunk.memory);
+
+                    let memory = Arc::try_unwrap(chunk.memory)
+                        .expect("Memory shared after last block deallocated");
+
+                    device.deallocate_memory(memory);
                     *allocations_remains += 1;
                     heap.dealloc(chunk.size);
 

--- a/gpu-alloc/src/lib.rs
+++ b/gpu-alloc/src/lib.rs
@@ -31,6 +31,7 @@ mod heap;
 mod linear;
 mod slab;
 mod usage;
+mod util;
 
 pub use {
     self::{allocator::*, block::MemoryBlock, config::*, error::*, usage::*},

--- a/gpu-alloc/src/linear.rs
+++ b/gpu-alloc/src/linear.rs
@@ -1,13 +1,13 @@
 use {
     crate::{align_down, align_up, error::AllocationError, heap::Heap, MemoryBounds},
-    alloc::collections::VecDeque,
+    alloc::{collections::VecDeque, sync::Arc},
     core::{convert::TryFrom as _, ptr::NonNull},
     gpu_alloc_types::{AllocationFlags, DeviceMapError, MemoryDevice, MemoryPropertyFlags},
 };
 
 #[derive(Debug)]
 pub(crate) struct LinearBlock<M> {
-    pub memory: M,
+    pub memory: Arc<M>,
     pub ptr: Option<NonNull<u8>>,
     pub offset: u64,
     pub size: u64,
@@ -19,27 +19,22 @@ unsafe impl<M> Send for LinearBlock<M> where M: Send {}
 
 #[derive(Debug)]
 struct Chunk<M> {
-    memory: M,
+    memory: Arc<M>,
     offset: u64,
-    allocated: u64,
     ptr: Option<NonNull<u8>>,
 }
 
 impl<M> Chunk<M> {
     fn exhaust(self) -> ExhaustedChunk<M> {
-        debug_assert_ne!(self.allocated, 0, "Unused chunk cannot be exhaused");
-
         ExhaustedChunk {
             memory: self.memory,
-            allocated: self.allocated,
         }
     }
 }
 
 #[derive(Debug)]
 struct ExhaustedChunk<M> {
-    memory: M,
-    allocated: u64,
+    memory: Arc<M>,
 }
 
 #[derive(Debug)]
@@ -88,10 +83,7 @@ where
         flags: AllocationFlags,
         heap: &mut Heap,
         allocations_remains: &mut u32,
-    ) -> Result<LinearBlock<M>, AllocationError>
-    where
-        M: Clone,
-    {
+    ) -> Result<LinearBlock<M>, AllocationError> {
         debug_assert!(
             self.chunk_size >= size,
             "GpuAllocator must not request allocations equal or greater to chunks size"
@@ -125,13 +117,14 @@ where
                     return Err(AllocationError::TooManyObjects);
                 }
 
-                let memory = device.allocate_memory(self.chunk_size, self.memory_type, flags)?;
+                let mut memory =
+                    device.allocate_memory(self.chunk_size, self.memory_type, flags)?;
 
                 *allocations_remains -= 1;
                 heap.alloc(self.chunk_size);
 
                 let ptr = if host_visible {
-                    match device.map_memory(&memory, 0, self.chunk_size) {
+                    match device.map_memory(&mut memory, 0, self.chunk_size) {
                         Ok(ptr) => Some(ptr),
                         Err(DeviceMapError::MapFailed) => {
                             #[cfg(feature = "tracing")]
@@ -155,10 +148,11 @@ where
                     None
                 };
 
+                let memory = Arc::new(memory);
+
                 let ready = ready.get_or_insert(Chunk {
                     ptr,
                     memory,
-                    allocated: 0,
                     offset: 0,
                 });
 
@@ -198,18 +192,19 @@ where
                     let chunk = self.ready.as_mut().expect(
                         "Chunk index is out of bounds. Probably incorrect allocator instance",
                     );
-                    chunk.allocated -= 1;
-                    if chunk.allocated == 0 {
+                    drop(block);
+
+                    if is_unique(&mut chunk.memory) {
                         // Reuse chunk.
                         chunk.offset = 0;
                     }
                 } else {
-                    let chunk = &mut self.exhausted[chunk_offset].as_mut().expect("Chunk index points to deallocated chunk. Probably incorrect allocator instance");
-                    chunk.allocated -= 1;
+                    let chunk = self.exhausted[chunk_offset].as_mut().expect("Chunk index points to deallocated chunk. Probably incorrect allocator instance");
+                    drop(block);
 
-                    if chunk.allocated == 0 {
+                    if is_unique(&mut chunk.memory) {
                         let memory = self.exhausted[chunk_offset].take().unwrap().memory;
-                        drop(block);
+                        let memory = Arc::try_unwrap(memory).expect("Uniqueness checked");
                         device.deallocate_memory(memory);
                         *allocations_remains += 1;
                         heap.dealloc(self.chunk_size);
@@ -231,12 +226,21 @@ where
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
     pub unsafe fn cleanup(&mut self, device: &impl MemoryDevice<M>) {
-        if let Some(chunk) = self.ready.take() {
-            assert_eq!(
-                chunk.allocated, 0,
+        if let Some(mut chunk) = self.ready.take() {
+            debug_assert!(
+                is_unique(&mut chunk.memory),
                 "All blocks must be deallocated before cleanup"
             );
-            device.deallocate_memory(chunk.memory);
+
+            match Arc::try_unwrap(chunk.memory) {
+                Ok(memory) => device.deallocate_memory(memory),
+                #[cfg(feature = "tracing")]
+                Err(_) => {
+                    tracing::error!("Cleanup before all memory blocks are deallocated");
+                }
+                #[cfg(not(feature = "tracing"))]
+                _ => {}
+            }
         }
 
         assert!(
@@ -256,10 +260,7 @@ where
         exhausted: u64,
         size: u64,
         align_mask: u64,
-    ) -> LinearBlock<M>
-    where
-        M: Clone,
-    {
+    ) -> LinearBlock<M> {
         debug_assert!(
             fits(chunk_size, chunk.offset, size, align_mask),
             "Must be checked in caller"
@@ -268,15 +269,15 @@ where
         let offset =
             align_up(chunk.offset, align_mask).expect("Chunk must be checked to fit allocation");
 
-        chunk.offset = offset + size;
-        chunk.allocated += 1;
-
         debug_assert!(
             offset
                 .checked_add(size)
                 .map_or(false, |end| end <= chunk_size),
             "Offset + size is not in chunk bounds"
         );
+
+        chunk.offset = offset + size;
+
         LinearBlock {
             memory: chunk.memory.clone(),
             ptr: chunk
@@ -304,4 +305,14 @@ where
         Ok(r) => core::cmp::min(l, r),
         Err(_) => l,
     }
+}
+
+fn is_unique<M>(arc: &mut Arc<M>) -> bool {
+    let strong_count = Arc::strong_count(&*arc);
+    debug_assert_ne!(strong_count, 0);
+    debug_assert!(
+        strong_count > 1 || Arc::get_mut(arc).is_some(),
+        "`Weak` pointers are never constructed"
+    );
+    strong_count == 1
 }

--- a/gpu-alloc/src/slab.rs
+++ b/gpu-alloc/src/slab.rs
@@ -60,12 +60,12 @@ impl<T> Slab<T> {
         }
     }
 
-    // pub fn get(&self, index: usize) -> &T {
-    //     match self.entries.get(index) {
-    //         Some(Entry::Occupied(value)) => value,
-    //         _ => panic!("Invalid index"),
-    //     }
-    // }
+    pub fn get(&self, index: usize) -> &T {
+        match self.entries.get(index) {
+            Some(Entry::Occupied(value)) => value,
+            _ => panic!("Invalid index"),
+        }
+    }
 
     pub fn get_mut(&mut self, index: usize) -> &mut T {
         match self.entries.get_mut(index) {

--- a/gpu-alloc/src/util.rs
+++ b/gpu-alloc/src/util.rs
@@ -1,0 +1,43 @@
+use alloc::sync::Arc;
+
+/// Guarantees uniquencess only if `Weak` pointers are never created
+/// from this `Arc` or clones.
+pub(crate) fn is_arc_unique<M>(arc: &mut Arc<M>) -> bool {
+    let strong_count = Arc::strong_count(&*arc);
+    debug_assert_ne!(strong_count, 0, "This Arc should exist");
+
+    debug_assert!(
+        strong_count > 1 || Arc::get_mut(arc).is_some(),
+        "`Weak` pointer exists"
+    );
+
+    strong_count == 1
+}
+
+/// Can be used instead of `Arc::try_unwrap(arc).unwrap()`
+/// when it is guaranteed to succeed.
+pub(crate) unsafe fn arc_unwrap<M>(arc: Arc<M>) -> M {
+    use core::{mem::ManuallyDrop, ptr::read};
+
+    // Get raw pointer to inner value.
+    let raw = Arc::into_raw(arc);
+
+    // As `Arc` is unique and no Weak pointers exist
+    // it won't be dereferenced elsewhere.
+    let inner = read(raw);
+
+    // Cast to `ManuallyDrop` which guarantees to have same layout
+    // and will skip dropping.
+    drop(Arc::from_raw(raw as *const ManuallyDrop<M>));
+    inner
+}
+
+/// Can be used instead of `Arc::try_unwrap`
+/// only if `Weak` pointers are never created from this `Arc` or clones.
+pub(crate) unsafe fn try_arc_unwrap<M>(mut arc: Arc<M>) -> Option<M> {
+    if is_arc_unique(&mut arc) {
+        Some(arc_unwrap(arc))
+    } else {
+        None
+    }
+}

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -123,7 +123,7 @@ impl MemoryDevice<usize> for MockMemoryDevice {
     #[tracing::instrument(skip(self))]
     unsafe fn map_memory(
         &self,
-        memory: &usize,
+        memory: &mut usize,
         offset: u64,
         size: u64,
     ) -> Result<NonNull<u8>, DeviceMapError> {
@@ -163,7 +163,7 @@ impl MemoryDevice<usize> for MockMemoryDevice {
         Ok(NonNull::from(&mut (&mut *mapping.content.get())[0]))
     }
 
-    unsafe fn unmap_memory(&self, memory: &usize) {
+    unsafe fn unmap_memory(&self, memory: &mut usize) {
         let mut allocations = self.allocations.borrow_mut();
         let memory = allocations
             .get_mut(*memory)

--- a/types/src/device.rs
+++ b/types/src/device.rs
@@ -114,7 +114,7 @@ pub trait MemoryDevice<M> {
     ///   memory object was allocated from this device.
     unsafe fn map_memory(
         &self,
-        memory: &M,
+        memory: &mut M,
         offset: u64,
         size: u64,
     ) -> Result<NonNull<u8>, DeviceMapError>;
@@ -125,7 +125,7 @@ pub trait MemoryDevice<M> {
     ///
     /// * Memory object must have been allocated from this device.
     /// * Memory object must be mapped
-    unsafe fn unmap_memory(&self, memory: &M);
+    unsafe fn unmap_memory(&self, memory: &mut M);
 
     /// Invalidates ranges of memory mapped regions.
     ///

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
 


### PR DESCRIPTION
Now those methods require &mut M
e.g. externally synchronized memory object

Fixes #33