### PR TITLE
Update erupt to 0.17.1+169

### DIFF
--- a/erupt/Cargo.toml
+++ b/erupt/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/zakarumych/gpu-alloc"
 [dependencies]
 gpu-alloc-types = { path = "../types", version = "0.2" }
 tracing = { version = "0.1", features = ["attributes"], optional = true }
-erupt = { version = "0.16", default-features = false, features = ["loading"] }
+erupt = { version = "0.17", default-features = false, features = ["loading"] }
 tinyvec = { version = "1.0",  default-features = false, features = ["alloc"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,7 @@ gpu-alloc-gfx = { path = "../gfx", version = "=0.2", optional = true }
 gfx-hal = { version = "0.6", optional = true }
 gfx-backend-vulkan = { version = "0.6", optional = true }
 gpu-alloc-erupt = { path = "../erupt", version = "=0.2", optional = true }
-erupt = { version = "0.16", optional = true, features = ["loading"] }
+erupt = { version = "0.17", optional = true, features = ["loading"] }
 
 [[bin]]
 name = "mock"


### PR DESCRIPTION
[erupt changelog](https://gitlab.com/Friz64/erupt/-/blob/master/CHANGELOG.md#0170169-2021-02-09)