### PR TITLE
Fix some typos

### DIFF
--- a/gpu-alloc/src/allocator.rs
+++ b/gpu-alloc/src/allocator.rs
@@ -21,9 +21,9 @@ use {
 /// Memory allocator for Vulkan-like APIs.
 #[derive(Debug)]
 pub struct GpuAllocator<M> {
-    dedicated_treshold: u64,
-    preferred_dedicated_treshold: u64,
-    transient_dedicated_treshold: u64,
+    dedicated_threshold: u64,
+    preferred_dedicated_threshold: u64,
+    transient_dedicated_threshold: u64,
     max_memory_allocation_size: u64,
     memory_for_usage: MemoryForUsage,
     memory_types: Box<[MemoryType]>,
@@ -63,7 +63,7 @@ where
     M: MemoryBounds + 'static,
 {
     /// Creates  new instance of `GpuAllocator`.
-    /// Provided `DeviceProperties` should match propertices of `MemoryDevice` that will be used
+    /// Provided `DeviceProperties` should match properties of `MemoryDevice` that will be used
     /// with created `GpuAllocator` instance.
     #[cfg_attr(feature = "tracing", tracing::instrument)]
     pub fn new(config: Config, props: DeviceProperties<'_>) -> Self {
@@ -78,17 +78,17 @@ where
         );
 
         GpuAllocator {
-            dedicated_treshold: config
-                .dedicated_treshold
+            dedicated_threshold: config
+                .dedicated_threshold
                 .max(props.max_memory_allocation_size),
-            preferred_dedicated_treshold: config
-                .preferred_dedicated_treshold
-                .min(config.dedicated_treshold)
+            preferred_dedicated_threshold: config
+                .preferred_dedicated_threshold
+                .min(config.dedicated_threshold)
                 .max(props.max_memory_allocation_size),
 
-            transient_dedicated_treshold: config
-                .transient_dedicated_treshold
-                .max(config.dedicated_treshold)
+            transient_dedicated_threshold: config
+                .transient_dedicated_threshold
+                .max(config.dedicated_threshold)
                 .max(props.max_memory_allocation_size),
 
             max_memory_allocation_size: props.max_memory_allocation_size,
@@ -223,23 +223,23 @@ where
             let strategy = match (dedicated, transient) {
                 (Some(Dedicated::Required), _) => Strategy::Dedicated,
                 (Some(Dedicated::Preferred), _)
-                    if request.size >= self.preferred_dedicated_treshold =>
+                    if request.size >= self.preferred_dedicated_threshold =>
                 {
                     Strategy::Dedicated
                 }
                 (_, true) => {
-                    let treshold = self.transient_dedicated_treshold.min(linear_chunk);
+                    let threshold = self.transient_dedicated_threshold.min(linear_chunk);
 
-                    if request.size < treshold {
+                    if request.size < threshold {
                         Strategy::Linear
                     } else {
                         Strategy::Dedicated
                     }
                 }
                 (_, false) => {
-                    let treshold = self.dedicated_treshold.min(heap.size() / 32);
+                    let threshold = self.dedicated_threshold.min(heap.size() / 32);
 
-                    if request.size < treshold {
+                    if request.size < threshold {
                         Strategy::Buddy
                     } else {
                         Strategy::Dedicated

--- a/gpu-alloc/src/config.rs
+++ b/gpu-alloc/src/config.rs
@@ -7,21 +7,21 @@ pub struct Config {
     /// Size in bytes of request that will be served by dedicated memory object.
     /// This value should be large enough to not exhaust memory object limit
     /// and not use slow memory object allocation when it is not necessary.
-    pub dedicated_treshold: u64,
+    pub dedicated_threshold: u64,
 
     /// Size in bytes of request that will be served by dedicated memory object if preferred.
     /// This value should be large enough to not exhaust memory object limit
     /// and not use slow memory object allocation when it is not necessary.
     ///
-    /// This won't make much sense if this value is larger than `dedicated_treshold`.
-    pub preferred_dedicated_treshold: u64,
+    /// This won't make much sense if this value is larger than `dedicated_threshold`.
+    pub preferred_dedicated_threshold: u64,
 
     /// Size in bytes of transient memory request that will be served by dedicated memory object.
     /// This value should be large enough to not exhaust memory object limit
     /// and not use slow memory object allocation when it is not necessary.
     ///
-    /// This won't make much sense if this value is lesser than `dedicated_treshold`.
-    pub transient_dedicated_treshold: u64,
+    /// This won't make much sense if this value is lesser than `dedicated_threshold`.
+    pub transient_dedicated_threshold: u64,
 
     /// Size in bytes for chunks for linear allocator.
     pub linear_chunk: u64,
@@ -49,9 +49,9 @@ impl Config {
         let potato = Config::i_am_potato();
 
         Config {
-            dedicated_treshold: potato.dedicated_treshold * 1024,
-            preferred_dedicated_treshold: potato.preferred_dedicated_treshold * 1024,
-            transient_dedicated_treshold: potato.transient_dedicated_treshold * 1024,
+            dedicated_threshold: potato.dedicated_threshold * 1024,
+            preferred_dedicated_threshold: potato.preferred_dedicated_threshold * 1024,
+            transient_dedicated_threshold: potato.transient_dedicated_threshold * 1024,
             linear_chunk: potato.linear_chunk * 1024,
             minimal_buddy_size: potato.minimal_buddy_size * 1024,
             initial_buddy_dedicated_size: potato.initial_buddy_dedicated_size * 1024,
@@ -61,9 +61,9 @@ impl Config {
     /// Returns default configuration for average sized potato.
     pub fn i_am_potato() -> Self {
         Config {
-            dedicated_treshold: 32 * 1024,
-            preferred_dedicated_treshold: 1024,
-            transient_dedicated_treshold: 128 * 1024,
+            dedicated_threshold: 32 * 1024,
+            preferred_dedicated_threshold: 1024,
+            transient_dedicated_threshold: 128 * 1024,
             linear_chunk: 128 * 1024,
             minimal_buddy_size: 1,
             initial_buddy_dedicated_size: 8 * 1024,

--- a/gpu-alloc/src/error.rs
+++ b/gpu-alloc/src/error.rs
@@ -15,7 +15,7 @@ pub enum AllocationError {
     /// Deallocating host memory may increase chance that another allocation would succeed.
     OutOfHostMemory,
 
-    /// Allocation request cannot be fullfilled as no available memory types allowed
+    /// Allocation request cannot be fulfilled as no available memory types allowed
     /// by `Request.memory_types` mask is compatible with `request.usage`.
     NoCompatibleMemoryTypes,
 

--- a/gpu-alloc/src/lib.rs
+++ b/gpu-alloc/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Request {
     pub size: u64,
 
     /// Minimal alignment mask required.
-    /// Returnd block may have larger alignment,
+    /// Returned block may have larger alignment,
     /// use `MemoryBlock::align` to learn actual alignment of returned block.
     pub align_mask: u64,
 
@@ -62,14 +62,14 @@ pub struct Request {
     pub memory_types: u32,
 }
 
-/// Aligns `value` up to `align_maks`
+/// Aligns `value` up to `align_mask`
 /// Returns smallest integer not lesser than `value` aligned by `align_mask`.
 /// Returns `None` on overflow.
 pub(crate) fn align_up(value: u64, align_mask: u64) -> Option<u64> {
     Some(value.checked_add(align_mask)? & !align_mask)
 }
 
-/// Align `value` down to `align_maks`
+/// Align `value` down to `align_mask`
 /// Returns largest integer not bigger than `value` aligned by `align_mask`.
 pub(crate) fn align_down(value: u64, align_mask: u64) -> u64 {
     value & !align_mask

--- a/gpu-alloc/src/usage.rs
+++ b/gpu-alloc/src/usage.rs
@@ -142,7 +142,7 @@ fn compatible(usage: UsageFlags, flags: MemoryPropertyFlags) -> bool {
 fn priority(usage: UsageFlags, flags: MemoryPropertyFlags) -> u32 {
     type Flags = MemoryPropertyFlags;
 
-    // Higly prefer device local memory when `FAST_DEVICE_ACCESS` usage is specified
+    // Highly prefer device local memory when `FAST_DEVICE_ACCESS` usage is specified
     // or usage is empty.
     let device_local: bool = flags.contains(Flags::DEVICE_LOCAL)
         ^ (usage.is_empty() || usage.contains(UsageFlags::FAST_DEVICE_ACCESS));
@@ -162,6 +162,6 @@ fn priority(usage: UsageFlags, flags: MemoryPropertyFlags) -> u32 {
     let coherent: bool = flags.contains(Flags::HOST_COHERENT)
         ^ (usage.intersects(UsageFlags::UPLOAD | UsageFlags::DOWNLOAD));
 
-    // Each boolean is false if flags are prefered.
+    // Each boolean is false if flags are preferred.
     device_local as u32 * 4 + cached as u32 * 2 + coherent as u32
 }

--- a/gpu-alloc/src/util.rs
+++ b/gpu-alloc/src/util.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-/// Guarantees uniquencess only if `Weak` pointers are never created
+/// Guarantees uniqueness only if `Weak` pointers are never created
 /// from this `Arc` or clones.
 pub(crate) fn is_arc_unique<M>(arc: &mut Arc<M>) -> bool {
     let strong_count = Arc::strong_count(&*arc);

--- a/types/src/device.rs
+++ b/types/src/device.rs
@@ -84,7 +84,7 @@ pub trait MemoryDevice<M> {
     /// # Safety
     ///
     /// `memory_type` must be valid index for memory type associated with this device.
-    /// Retreiving this information is implementation specific.
+    /// Retrieving this information is implementation specific.
     ///
     /// `flags` must be supported by the device.
     unsafe fn allocate_memory(

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -42,7 +42,7 @@ pub struct MemoryType {
     /// Heap index of the memory type.
     pub heap: u32,
 
-    /// Propety flags of the memory type.
+    /// Property flags of the memory type.
     pub props: MemoryPropertyFlags,
 }
 


### PR DESCRIPTION
Note: this is a breaking change under semver because public fields have been renamed from `xyz_treshold` to `xyz_threshold`