### PR TITLE
Update erupt to 0.18.0+174

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supported Rust Versions
 The minimum supported version is 1.40.
 The current version is not guaranteed to build on Rust versions earlier than the minimum supported version.
 
-`gpu-alloc-erupt` crate requires version 1.46 or higher due to dependency on `erupt` crate.
+`gpu-alloc-erupt` crate requires version 1.48 or higher due to dependency on `erupt` crate.
 
 ## License
 

--- a/README.tpl
+++ b/README.tpl
@@ -13,7 +13,7 @@ Supported Rust Versions
 The minimum supported version is 1.40.
 The current version is not guaranteed to build on Rust versions earlier than the minimum supported version.
 
-`gpu-alloc-erupt` crate requires version 1.46 or higher due to dependency on `erupt` crate.
+`gpu-alloc-erupt` crate requires version 1.48 or higher due to dependency on `erupt` crate.
 
 ## License
 

--- a/erupt/Cargo.toml
+++ b/erupt/Cargo.toml
@@ -13,5 +13,5 @@ repository = "https://github.com/zakarumych/gpu-alloc"
 [dependencies]
 gpu-alloc-types = { path = "../types", version = "0.2" }
 tracing = { version = "0.1", features = ["attributes"], optional = true }
-erupt = { version = "0.17", default-features = false, features = ["loading"] }
+erupt = { version = "0.18", default-features = false, features = ["loading"] }
 tinyvec = { version = "1.0",  default-features = false, features = ["alloc"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,7 +18,7 @@ gpu-alloc-gfx = { path = "../gfx", version = "=0.3", optional = true }
 gfx-hal = { version = "0.7", optional = true }
 gfx-backend-vulkan = { version = "0.7", optional = true }
 gpu-alloc-erupt = { path = "../erupt", version = "=0.3", optional = true }
-erupt = { version = "0.17", optional = true, features = ["loading"] }
+erupt = { version = "0.18", optional = true, features = ["loading"] }
 
 tracing-subscriber = { version = "0.2", features = ["fmt", "env-filter"] }
 tracing-error = { version = "0.1" }


### PR DESCRIPTION
[erupt changelog](https://gitlab.com/Friz64/erupt/-/blob/master/CHANGELOG.md#0180174-2021-03-29)