### PR TITLE
Update to erupt 0.20

### DIFF
--- a/erupt/Cargo.toml
+++ b/erupt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu-alloc-erupt"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Zakarum <zakarumych@ya.ru>"]
 edition = "2018"
 description = "`erupt` backend for `gfx-alloc`"
@@ -15,5 +15,5 @@ categories = ["graphics", "memory-management", "no-std", "game-development"]
 [dependencies]
 gpu-alloc-types = { path = "../types", version = "0.2" }
 tracing = { version = "0.1", features = ["attributes"], optional = true }
-erupt = { version = "0.19", default-features = false, features = ["loading"] }
+erupt = { version = "0.20", default-features = false, features = ["loading"] }
 tinyvec = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,8 +17,8 @@ gpu-alloc-mock = { path = "../mock", version = "=0.2", optional = true }
 gpu-alloc-gfx = { path = "../gfx", version = "=0.3", optional = true }
 gfx-hal = { version = "0.8", optional = true }
 gfx-backend-vulkan = { version = "0.8", optional = true }
-gpu-alloc-erupt = { path = "../erupt", version = "=0.5", optional = true }
-erupt = { version = "0.19", optional = true, features = ["loading"] }
+gpu-alloc-erupt = { path = "../erupt", version = "=0.6", optional = true }
+erupt = { version = "0.20", optional = true, features = ["loading"] }
 gpu-alloc-ash = { path = "../ash", version = "=0.2", optional = true }
 ash = { version = "0.33", default-features = false, features = ["libloading"], optional = true }
 


### PR DESCRIPTION
[Changelog](https://gitlab.com/Friz64/erupt/-/blob/main/CHANGELOG.md#0200190-2021-08-30)