### PR TITLE
make GpuAllocator's public methods' call sites more concise

### DIFF
--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -74,6 +74,30 @@
 //!
 //!     unsafe { allocator.dealloc(AshMemoryDevice::wrap(&device), block) }
 //!
+//!     // the `ash::Device` also implements `AsRef<AshMemoryDevice>`
+//!     // you can pass a reference of `ash::Device` directly as argument
+//!     let mut block = unsafe {
+//!         allocator.alloc(
+//!             &device,
+//!             Request {
+//!                 size: 10,
+//!                 align_mask: 1,
+//!                 usage: UsageFlags::HOST_ACCESS,
+//!                 memory_types: !0,
+//!             },
+//!         )
+//!     }?;
+//!
+//!     unsafe {
+//!         block.write_bytes(
+//!             &device,
+//!             0,
+//!             &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+//!         )
+//!     }?;
+//!
+//!     unsafe { allocator.dealloc(&device, block) }
+//!
 //!     Ok(())
 //! }
 //! ```

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -104,6 +104,20 @@ impl AshMemoryDevice {
     }
 }
 
+impl AsRef<AshMemoryDevice> for Device {
+    fn as_ref(&self) -> &AshMemoryDevice {
+        AshMemoryDevice::wrap(self)
+    }
+}
+
+// AsRef does not have a blanket implementation. need to add this impl so that
+// old user code (i.e. explicit wrap) still compiles without any change
+impl AsRef<AshMemoryDevice> for AshMemoryDevice {
+    fn as_ref(&self) -> &AshMemoryDevice {
+        self
+    }
+}
+
 impl MemoryDevice<vk::DeviceMemory> for AshMemoryDevice {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn allocate_memory(

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -105,6 +105,7 @@ impl AshMemoryDevice {
 }
 
 impl AsRef<AshMemoryDevice> for Device {
+    #[inline(always)]
     fn as_ref(&self) -> &AshMemoryDevice {
         AshMemoryDevice::wrap(self)
     }
@@ -113,6 +114,7 @@ impl AsRef<AshMemoryDevice> for Device {
 // AsRef does not have a blanket implementation. need to add this impl so that
 // old user code (i.e. explicit wrap) still compiles without any change
 impl AsRef<AshMemoryDevice> for AshMemoryDevice {
+    #[inline(always)]
     fn as_ref(&self) -> &AshMemoryDevice {
         self
     }

--- a/erupt/src/lib.rs
+++ b/erupt/src/lib.rs
@@ -78,6 +78,30 @@
 //!
 //!     unsafe { allocator.dealloc(EruptMemoryDevice::wrap(&device), block) }
 //!
+//!     // the `erupt::DeviceLoader` also implements `AsRef<EruptMemoryDevice>`
+//!     // you can pass a reference of `erupt::DeviceLoader` directly as argument
+//!     let mut block = unsafe {
+//!         allocator.alloc(
+//!             &device,
+//!             Request {
+//!                 size: 10,
+//!                 align_mask: 1,
+//!                 usage: UsageFlags::HOST_ACCESS,
+//!                 memory_types: !0,
+//!             },
+//!         )
+//!     }?;
+//!
+//!     unsafe {
+//!         block.write_bytes(
+//!             &device,
+//!             0,
+//!             &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+//!         )
+//!     }?;
+//!
+//!     unsafe { allocator.dealloc(&device, block) }
+//!
 //!     Ok(())
 //! }
 //! ```

--- a/erupt/src/lib.rs
+++ b/erupt/src/lib.rs
@@ -108,12 +108,14 @@ impl EruptMemoryDevice {
 }
 
 impl AsRef<EruptMemoryDevice> for DeviceLoader {
+    #[inline(always)]
     fn as_ref(&self) -> &EruptMemoryDevice {
         EruptMemoryDevice::wrap(self)
     }
 }
 
 impl AsRef<EruptMemoryDevice> for EruptMemoryDevice {
+    #[inline(always)]
     fn as_ref(&self) -> &EruptMemoryDevice {
         self
     }

--- a/erupt/src/lib.rs
+++ b/erupt/src/lib.rs
@@ -107,6 +107,18 @@ impl EruptMemoryDevice {
     }
 }
 
+impl AsRef<EruptMemoryDevice> for DeviceLoader {
+    fn as_ref(&self) -> &EruptMemoryDevice {
+        EruptMemoryDevice::wrap(self)
+    }
+}
+
+impl AsRef<EruptMemoryDevice> for EruptMemoryDevice {
+    fn as_ref(&self) -> &EruptMemoryDevice {
+        self
+    }
+}
+
 impl MemoryDevice<vk1_0::DeviceMemory> for EruptMemoryDevice {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     unsafe fn allocate_memory(

--- a/examples/src/ash.rs
+++ b/examples/src/ash.rs
@@ -72,5 +72,29 @@ fn main() -> eyre::Result<()> {
 
     unsafe { allocator.dealloc(AshMemoryDevice::wrap(&device), block) }
 
+    // the `ash::Device` also implements `AsRef<AshMemoryDevice>`
+    // you can pass a reference of `ash::Device` directly as argument
+    let mut block = unsafe {
+        allocator.alloc(
+            &device,
+            Request {
+                size: 10,
+                align_mask: 1,
+                usage: UsageFlags::HOST_ACCESS,
+                memory_types: !0,
+            },
+        )
+    }?;
+
+    unsafe {
+        block.write_bytes(
+            &device,
+            0,
+            &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        )
+    }?;
+
+    unsafe { allocator.dealloc(&device, block) }
+
     Ok(())
 }

--- a/examples/src/erupt.rs
+++ b/examples/src/erupt.rs
@@ -70,5 +70,29 @@ fn main() -> eyre::Result<()> {
 
     unsafe { allocator.dealloc(EruptMemoryDevice::wrap(&device), block) }
 
+    // the `erupt::DeviceLoader` also implements `AsRef<EruptMemoryDevice>`
+    // you can pass a reference of `erupt::DeviceLoader` directly as argument
+    let mut block = unsafe {
+        allocator.alloc(
+            &device,
+            Request {
+                size: 10,
+                align_mask: 1,
+                usage: UsageFlags::HOST_ACCESS,
+                memory_types: !0,
+            },
+        )
+    }?;
+
+    unsafe {
+        block.write_bytes(
+            &device,
+            0,
+            &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        )
+    }?;
+
+    unsafe { allocator.dealloc(&device, block) }
+
     Ok(())
 }

--- a/gpu-alloc/src/allocator.rs
+++ b/gpu-alloc/src/allocator.rs
@@ -122,11 +122,14 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn alloc<MD: MemoryDevice<M>>(
+    pub unsafe fn alloc<MD>(
         &mut self,
         device: &impl AsRef<MD>,
         request: Request,
-    ) -> Result<MemoryBlock<M>, AllocationError> {
+    ) -> Result<MemoryBlock<M>, AllocationError>
+    where
+        MD: MemoryDevice<M>,
+    {
         self.alloc_internal(device.as_ref(), request, None)
     }
 
@@ -141,12 +144,15 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn alloc_with_dedicated<MD: MemoryDevice<M>>(
+    pub unsafe fn alloc_with_dedicated<MD>(
         &mut self,
         device: &impl AsRef<MD>,
         request: Request,
         dedicated: Dedicated,
-    ) -> Result<MemoryBlock<M>, AllocationError> {
+    ) -> Result<MemoryBlock<M>, AllocationError>
+    where
+        MD: MemoryDevice<M>,
+    {
         self.alloc_internal(device.as_ref(), request, Some(dedicated))
     }
 
@@ -478,7 +484,10 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn dealloc<MD: MemoryDevice<M>>(&mut self, device: &impl AsRef<MD>, block: MemoryBlock<M>) {
+    pub unsafe fn dealloc<MD>(&mut self, device: &impl AsRef<MD>, block: MemoryBlock<M>)
+    where
+        MD: MemoryDevice<M>,
+    {
         let device = device.as_ref();
         let memory_type = block.memory_type();
         let offset = block.offset();
@@ -575,7 +584,10 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn cleanup<MD: MemoryDevice<M>>(&mut self, device: &impl AsRef<MD>) {
+    pub unsafe fn cleanup<MD>(&mut self, device: &impl AsRef<MD>)
+    where
+        MD: MemoryDevice<M>,
+    {
         for (index, allocator) in self
             .freelist_allocators
             .iter_mut()

--- a/gpu-alloc/src/allocator.rs
+++ b/gpu-alloc/src/allocator.rs
@@ -122,12 +122,12 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn alloc(
+    pub unsafe fn alloc<MD: MemoryDevice<M>>(
         &mut self,
-        device: &impl MemoryDevice<M>,
+        device: &impl AsRef<MD>,
         request: Request,
     ) -> Result<MemoryBlock<M>, AllocationError> {
-        self.alloc_internal(device, request, None)
+        self.alloc_internal(device.as_ref(), request, None)
     }
 
     /// Allocates memory block from specified `device` according to the `request`.
@@ -141,13 +141,13 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn alloc_with_dedicated(
+    pub unsafe fn alloc_with_dedicated<MD: MemoryDevice<M>>(
         &mut self,
-        device: &impl MemoryDevice<M>,
+        device: &impl AsRef<MD>,
         request: Request,
         dedicated: Dedicated,
     ) -> Result<MemoryBlock<M>, AllocationError> {
-        self.alloc_internal(device, request, Some(dedicated))
+        self.alloc_internal(device.as_ref(), request, Some(dedicated))
     }
 
     unsafe fn alloc_internal(
@@ -478,7 +478,8 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn dealloc(&mut self, device: &impl MemoryDevice<M>, block: MemoryBlock<M>) {
+    pub unsafe fn dealloc<MD: MemoryDevice<M>>(&mut self, device: &impl AsRef<MD>, block: MemoryBlock<M>) {
+        let device = device.as_ref();
         let memory_type = block.memory_type();
         let offset = block.offset();
         let size = block.size();
@@ -574,13 +575,14 @@ where
     /// * Same `device` instance must be used for all interactions with one `GpuAllocator` instance
     ///   and memory blocks allocated from it
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, device)))]
-    pub unsafe fn cleanup(&mut self, device: &impl MemoryDevice<M>) {
+    pub unsafe fn cleanup<MD: MemoryDevice<M>>(&mut self, device: &impl AsRef<MD>) {
         for (index, allocator) in self
             .freelist_allocators
             .iter_mut()
             .enumerate()
             .filter_map(|(index, allocator)| Some((index, allocator.as_mut()?)))
         {
+            let device = device.as_ref();
             let memory_type = &self.memory_types[index];
             let heap = memory_type.heap;
             let heap = &mut self.memory_heaps[heap as usize];

--- a/gpu-alloc/src/block.rs
+++ b/gpu-alloc/src/block.rs
@@ -135,12 +135,15 @@ impl<M> MemoryBlock<M> {
     ///
     /// `block` must have been allocated from specified `device`.
     #[inline(always)]
-    pub unsafe fn map<MD: MemoryDevice<M>>(
+    pub unsafe fn map<MD>(
         &mut self,
         device: &impl AsRef<MD>,
         offset: u64,
         size: usize,
-    ) -> Result<NonNull<u8>, MapError> {
+    ) -> Result<NonNull<u8>, MapError>
+    where
+        MD: MemoryDevice<M>,
+    {
         let size_u64 = u64::try_from(size).expect("`size` doesn't fit device address space");
         assert!(offset < self.size, "`offset` is out of memory block bounds");
         assert!(
@@ -198,7 +201,10 @@ impl<M> MemoryBlock<M> {
     ///
     /// `block` must have been allocated from specified `device`.
     #[inline(always)]
-    pub unsafe fn unmap<MD: MemoryDevice<M>>(&mut self, device: &impl AsRef<MD>) -> bool {
+    pub unsafe fn unmap<MD>(&mut self, device: &impl AsRef<MD>) -> bool
+    where
+        MD: MemoryDevice<M>,
+    {
         if !release_mapping(&mut self.mapped) {
             return false;
         }
@@ -224,12 +230,15 @@ impl<M> MemoryBlock<M> {
     /// `block` must have been allocated from specified `device`.
     /// The caller must guarantee that any previously submitted command that reads or writes to this range has completed.
     #[inline(always)]
-    pub unsafe fn write_bytes<MD: MemoryDevice<M>>(
+    pub unsafe fn write_bytes<MD>(
         &mut self,
         device: &impl AsRef<MD>,
         offset: u64,
         data: &[u8],
-    ) -> Result<(), MapError> {
+    ) -> Result<(), MapError>
+    where
+        MD: MemoryDevice<M>,
+    {
         let size = data.len();
         let ptr = self.map(device, offset, size)?;
 
@@ -263,12 +272,15 @@ impl<M> MemoryBlock<M> {
     /// `block` must have been allocated from specified `device`.
     /// The caller must guarantee that any previously submitted command that reads to this range has completed.
     #[inline(always)]
-    pub unsafe fn read_bytes<MD: MemoryDevice<M>>(
+    pub unsafe fn read_bytes<MD>(
         &mut self,
         device: &impl AsRef<MD>,
         offset: u64,
         data: &mut [u8],
-    ) -> Result<(), MapError> {
+    ) -> Result<(), MapError>
+    where
+        MD: MemoryDevice<M>,
+    {
         #[cfg(feature = "tracing")]
         {
             if !self.cached() {

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -289,3 +289,11 @@ impl MemoryDevice<usize> for MockMemoryDevice {
         Ok(())
     }
 }
+
+// MockMemoryDevice is not a wrapper for external type in other crate,
+// this impl is needed to be compatible with the new signature of GpuAllocator.
+impl AsRef<MockMemoryDevice> for MockMemoryDevice {
+    fn as_ref(&self) -> &MockMemoryDevice {
+        self
+    }
+}

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -293,6 +293,7 @@ impl MemoryDevice<usize> for MockMemoryDevice {
 // MockMemoryDevice is not a wrapper for external type in other crate,
 // this impl is needed to be compatible with the new signature of GpuAllocator.
 impl AsRef<MockMemoryDevice> for MockMemoryDevice {
+    #[inline(always)]
     fn as_ref(&self) -> &MockMemoryDevice {
         self
     }


### PR DESCRIPTION
previously caller need to explicitly wrap the backend type (ash::Device or erupt::DeviceLoader), which is verbose and tedious:
```rust
let device: ash::Device;
let mut allocator: gpu_alloc::GpuAllocator<vk::DeviceMemory>;
//...
allocator.cleanup(gpu_alloc::AshMemoryDevice::wrap(&device));
```

by change the generic parameter type to `impl AsRef<MD>` where `MD: MemoryDevice<M>`, and by adding `impl`s for the appropriate backend wrapper types, the call site is much more concise:
```rust
let device: ash::Device;
let mut allocator: gpu_alloc::GpuAllocator<vk::DeviceMemory>;
//...
allocator.cleanup(&device);
```
