### PR TITLE
Bump `bitflags` to v2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,15 +31,15 @@ jobs:
       with:
         command: test
         args: --all --all-features
-  test-1_46:
+  test-1_60:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install 1.46.0 toolchain
+    - name: Install 1.60.0 toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: '1.46.0'
+        toolchain: '1.60.0'
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 mock = ["gpu-alloc-mock"]
 
 [dependencies]
-gpu-alloc = { path = "../gpu-alloc", version = "=0.5.3", features = ["tracing"] }
+gpu-alloc = { path = "../gpu-alloc", version = "=0.5.4", features = ["tracing"] }
 eyre = "0.6"
 color-eyre = "0.6"
 gpu-alloc-mock = { path = "../mock", version = "=0.2", optional = true }

--- a/gpu-alloc/Cargo.toml
+++ b/gpu-alloc/Cargo.toml
@@ -15,9 +15,10 @@ categories = ["graphics", "memory-management", "no-std", "game-development"]
 [features]
 std = []
 default = ["std"]
+serde = ["dep:serde", "bitflags/serde"]
 
 [dependencies]
 gpu-alloc-types = { path = "../types", version = "0.2" }
 tracing = { version = "0.1.27", optional = true, features = ["attributes"], default-features = false }
-bitflags = { version = "1.2", default-features = false }
+bitflags = { version = "2.0", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }

--- a/gpu-alloc/src/block.rs
+++ b/gpu-alloc/src/block.rs
@@ -86,8 +86,8 @@ impl<M> MemoryBlock<M> {
     pub fn memory(&self) -> &M {
         match &self.flavor {
             MemoryBlockFlavor::Dedicated { memory } => memory,
-            MemoryBlockFlavor::Buddy { memory, .. } => &**memory,
-            MemoryBlockFlavor::FreeList { memory, .. } => &**memory,
+            MemoryBlockFlavor::Buddy { memory, .. } => memory,
+            MemoryBlockFlavor::FreeList { memory, .. } => memory,
         }
     }
 

--- a/gpu-alloc/src/usage.rs
+++ b/gpu-alloc/src/usage.rs
@@ -7,6 +7,7 @@ bitflags::bitflags! {
     /// Memory usage type.
     /// Bits set define intended usage for requested memory.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct UsageFlags: u8 {
         /// Hints for allocator to find memory with faster device access.
         /// If no flags is specified than `FAST_DEVICE_ACCESS` is implied.

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -212,7 +212,7 @@ impl MemoryDevice<usize> for MockMemoryDevice {
                 tracing::warn!("Invalidating host-coherent memory");
             }
 
-            let mapped_size = (&*mapped.content.get()).len() as u64;
+            let mapped_size = (*mapped.content.get()).len() as u64;
 
             assert!(
                 range.offset >= mapped.offset,
@@ -261,7 +261,7 @@ impl MemoryDevice<usize> for MockMemoryDevice {
                 tracing::warn!("Invalidating host-coherent memory");
             }
 
-            let mapped_size = (&*mapped.content.get()).len() as u64;
+            let mapped_size = (*mapped.content.get()).len() as u64;
 
             assert!(
                 range.offset >= mapped.offset,

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["gpu", "vulkan", "allocation", "no-std"]
 categories = ["graphics", "memory-management", "no-std", "game-development"]
 
 [dependencies]
-bitflags = { version = "1.2", default-features = false }
+bitflags = { version = "2.0", default-features = false }

--- a/types/src/device.rs
+++ b/types/src/device.rs
@@ -67,6 +67,7 @@ pub struct DeviceProperties<'a> {
 bitflags::bitflags! {
     /// Allocation flags
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct AllocationFlags : u8 {
         /// Specifies that the memory can be used for buffers created
         /// with flag that allows fetching device address.

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -1,6 +1,7 @@
 bitflags::bitflags! {
     /// Memory properties type.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct MemoryPropertyFlags: u8 {
         /// This flag is set for device-local memory types.
         /// Device-local memory is situated "close" to the GPU cores


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented by the macro is now different.

I was a bit liberal with deriving `std` traits on public types, which mimics the behavior of `bitflags` v1, let me know if we don't need all these traits. Potentially we could at least drop `PartialOrd` and `Ord`.

Replaces https://github.com/zakarumych/gpu-alloc/pull/70.