### PR TITLE
Update to ash 0.38

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -15,5 +15,5 @@ categories = ["graphics", "memory-management", "no-std", "game-development"]
 [dependencies]
 gpu-alloc-types = { path = "../types", version = "=0.3.0" }
 tracing = { version = "0.1", features = ["attributes"], optional = true }
-ash = { version = "0.37", default-features = false }
+ash = { version = "0.38", default-features = false }
 tinyvec = { version = "1.0",  default-features = false, features = ["alloc"] }

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu-alloc-ash"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Zakarum <zakarumych@ya.ru>"]
 edition = "2018"
 description = "`ash` backend for `gpu-alloc`"

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpu-alloc-ash"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Zakarum <zakarumych@ya.ru>"]
 edition = "2018"
 description = "`ash` backend for `gpu-alloc`"

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -154,14 +154,14 @@ impl MemoryDevice<vk::DeviceMemory> for AshMemoryDevice {
     ) -> Result<vk::DeviceMemory, OutOfMemory> {
         assert!((flags & !(AllocationFlags::DEVICE_ADDRESS)).is_empty());
 
-        let mut info = vk::MemoryAllocateInfo::builder()
+        let mut info = vk::MemoryAllocateInfo::default()
             .allocation_size(size)
             .memory_type_index(memory_type);
 
         let mut info_flags;
 
         if flags.contains(AllocationFlags::DEVICE_ADDRESS) {
-            info_flags = vk::MemoryAllocateFlagsInfo::builder()
+            info_flags = vk::MemoryAllocateFlagsInfo::default()
                 .flags(vk::MemoryAllocateFlags::DEVICE_ADDRESS);
             info = info.push_next(&mut info_flags);
         }
@@ -217,11 +217,10 @@ impl MemoryDevice<vk::DeviceMemory> for AshMemoryDevice {
                 &ranges
                     .iter()
                     .map(|range| {
-                        vk::MappedMemoryRange::builder()
+                        vk::MappedMemoryRange::default()
                             .memory(*range.memory)
                             .offset(range.offset)
                             .size(range.size)
-                            .build()
                     })
                     .collect::<TinyVec<[_; 4]>>(),
             )
@@ -242,11 +241,10 @@ impl MemoryDevice<vk::DeviceMemory> for AshMemoryDevice {
                 &ranges
                     .iter()
                     .map(|range| {
-                        vk::MappedMemoryRange::builder()
+                        vk::MappedMemoryRange::default()
                             .memory(*range.memory)
                             .offset(range.offset)
                             .size(range.size)
-                            .build()
                     })
                     .collect::<TinyVec<[_; 4]>>(),
             )
@@ -282,7 +280,7 @@ pub unsafe fn device_properties(
 
     let buffer_device_address =
         if vk::api_version_major(version) >= 1 && vk::api_version_minor(version) >= 2 {
-            let mut features = PhysicalDeviceFeatures2::builder();
+            let mut features = PhysicalDeviceFeatures2::default();
             let mut bda_features = vk::PhysicalDeviceBufferDeviceAddressFeatures::default();
             features.p_next =
                 &mut bda_features as *mut vk::PhysicalDeviceBufferDeviceAddressFeatures as *mut _;


### PR DESCRIPTION
Update the ash package's ash version to 0.38.
I'm not sure how to update the version of `gpu-alloc-ash` as it seems to be synced with the `gpu-alloc` package.